### PR TITLE
replaced lodash.* dependencies with object-assign

### DIFF
--- a/build/components/ExpandableNavHeader.js
+++ b/build/components/ExpandableNavHeader.js
@@ -26,7 +26,7 @@ var ExpandableNavHeader = React.createClass({displayName: "ExpandableNavHeader",
     };
   },
   render:function() {
-    var headerStyle = assign(this.props.headerStyle, {
+    var headerStyle = assign({}, this.props.headerStyle, {
       display: 'block',
       float: 'none'
     });
@@ -35,8 +35,8 @@ var ExpandableNavHeader = React.createClass({displayName: "ExpandableNavHeader",
       fontWeight: 'bold',
       fontSize: 20,
     };
-    var smallStyle = assign(this.props.smallStyle, sharedStyle),
-        fullStyle = assign(this.props.fullStyle, sharedStyle);
+    var smallStyle = assign({}, this.props.smallStyle, sharedStyle),
+        fullStyle = assign({}, this.props.fullStyle, sharedStyle);
 
     var classes = "navbar-header " +
       joinClasses(this.props.className, this.props.expanded ? this.props.fullClass : this.props.smallClass);

--- a/build/components/ExpandableNavHeader.js
+++ b/build/components/ExpandableNavHeader.js
@@ -2,7 +2,7 @@
 
 var React = require('react');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavItem = require('./ExpandableNavItem');

--- a/build/components/ExpandableNavHeader.js
+++ b/build/components/ExpandableNavHeader.js
@@ -26,7 +26,7 @@ var ExpandableNavHeader = React.createClass({displayName: "ExpandableNavHeader",
     };
   },
   render:function() {
-    var headerStyle = assign({}, this.props.headerStyle, {
+    var headerStyle = assign(this.props.headerStyle || {}, {
       display: 'block',
       float: 'none'
     });
@@ -35,8 +35,8 @@ var ExpandableNavHeader = React.createClass({displayName: "ExpandableNavHeader",
       fontWeight: 'bold',
       fontSize: 20,
     };
-    var smallStyle = assign({}, this.props.smallStyle, sharedStyle),
-        fullStyle = assign({}, this.props.fullStyle, sharedStyle);
+    var smallStyle = assign(this.props.smallStyle || {}, sharedStyle),
+        fullStyle = assign(this.props.fullStyle || {}, sharedStyle);
 
     var classes = "navbar-header " +
       joinClasses(this.props.className, this.props.expanded ? this.props.fullClass : this.props.smallClass);

--- a/build/components/ExpandableNavItem.js
+++ b/build/components/ExpandableNavItem.js
@@ -2,7 +2,7 @@
 
 var React = require('react/addons');
 
-var assign = require('lodash.assign');
+var assign = require('object-assign');
 
 var ExpandableNavItem = React.createClass({displayName: "ExpandableNavItem",
   propTypes: {

--- a/build/components/ExpandableNavMenu.js
+++ b/build/components/ExpandableNavMenu.js
@@ -3,7 +3,7 @@
 var React = require('react/addons');
 
 var joinClasses = require('../utils/joinClasses'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavMenu = React.createClass({displayName: "ExpandableNavMenu",
   propTypes: {

--- a/build/components/ExpandableNavMenuItem.js
+++ b/build/components/ExpandableNavMenuItem.js
@@ -2,7 +2,7 @@
 
 var React = require('react');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavItem = require('./ExpandableNavItem');
@@ -78,13 +78,13 @@ var ExpandableNavMenuItem = React.createClass({displayName: "ExpandableNavMenuIt
         throw new Error('jQuery dependency must be passed to ExpandableNavMenuItem to enable tooltip function');
       }
       link = (
-        React.createElement("a", {ref: "link", href: url, onClick: this.handleClick, style: aStyle, "data-toggle": "menuitem-tooltip", "data-placement": "right", title: this.props.tooltip},
+        React.createElement("a", {ref: "link", href: url, onClick: this.handleClick, style: aStyle, "data-toggle": "menuitem-tooltip", "data-placement": "right", title: this.props.tooltip}, 
           React.createElement(ExpandableNavItem, React.__spread({style: navItemStyle, small: small, full: full, smallStyle: smallStyle, fullStyle: fullStyle},  props))
         )
       );
     } else {
       link = (
-        React.createElement("a", {ref: "link", href: url, onClick: this.handleClick, style: aStyle},
+        React.createElement("a", {ref: "link", href: url, onClick: this.handleClick, style: aStyle}, 
           React.createElement(ExpandableNavItem, React.__spread({style: navItemStyle, small: small, full: full, smallStyle: smallStyle, fullStyle: fullStyle},  props))
         )
       );

--- a/build/components/ExpandableNavMenuItem.js
+++ b/build/components/ExpandableNavMenuItem.js
@@ -58,11 +58,11 @@ var ExpandableNavMenuItem = React.createClass({displayName: "ExpandableNavMenuIt
     var aStyle = {
       padding: 0
     };
-    var smallStyle = assign({}, this.props.smallStyle, {
+    var smallStyle = assign(this.props.smallStyle || {}, {
       display: 'block',
       fontSize: 20,
     });
-    var fullStyle = assign({}, this.props.fullStyle, {
+    var fullStyle = assign(this.props.fullStyle || {}, {
       display: 'block',
       fontSize: 20,
     });

--- a/build/components/ExpandableNavMenuItem.js
+++ b/build/components/ExpandableNavMenuItem.js
@@ -58,11 +58,11 @@ var ExpandableNavMenuItem = React.createClass({displayName: "ExpandableNavMenuIt
     var aStyle = {
       padding: 0
     };
-    var smallStyle = assign(this.props.smallStyle, {
+    var smallStyle = assign({}, this.props.smallStyle, {
       display: 'block',
       fontSize: 20,
     });
-    var fullStyle = assign(this.props.fullStyle, {
+    var fullStyle = assign({}, this.props.fullStyle, {
       display: 'block',
       fontSize: 20,
     });

--- a/build/components/ExpandableNavPage.js
+++ b/build/components/ExpandableNavPage.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var React = require('react'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavPage = React.createClass({displayName: "ExpandableNavPage",
   propTypes: {

--- a/build/components/ExpandableNavToggleButton.js
+++ b/build/components/ExpandableNavToggleButton.js
@@ -2,7 +2,7 @@
 
 var React = require('react/addons');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavToggleButton = React.createClass({displayName: "ExpandableNavToggleButton",

--- a/build/components/ExpandableNavbar.js
+++ b/build/components/ExpandableNavbar.js
@@ -3,7 +3,7 @@
 var React = require('react/addons');
 
 var joinClasses = require('../utils/joinClasses'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavbar = React.createClass({displayName: "ExpandableNavbar",
   propTypes: {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "lodash.assign": "^2.4.1",
-    "lodash.zip": "^2.4.1"
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/src/components/ExpandableNavHeader.jsx
+++ b/src/components/ExpandableNavHeader.jsx
@@ -26,7 +26,7 @@ var ExpandableNavHeader = React.createClass({
     };
   },
   render() {
-    var headerStyle = assign(this.props.headerStyle, {
+    var headerStyle = assign({}, this.props.headerStyle, {
       display: 'block',
       float: 'none'
     });
@@ -35,8 +35,8 @@ var ExpandableNavHeader = React.createClass({
       fontWeight: 'bold',
       fontSize: 20,
     };
-    var smallStyle = assign(this.props.smallStyle, sharedStyle),
-        fullStyle = assign(this.props.fullStyle, sharedStyle);
+    var smallStyle = assign({}, this.props.smallStyle, sharedStyle),
+        fullStyle = assign({}, this.props.fullStyle, sharedStyle);
 
     var classes = "navbar-header " +
       joinClasses(this.props.className, this.props.expanded ? this.props.fullClass : this.props.smallClass);

--- a/src/components/ExpandableNavHeader.jsx
+++ b/src/components/ExpandableNavHeader.jsx
@@ -26,7 +26,7 @@ var ExpandableNavHeader = React.createClass({
     };
   },
   render() {
-    var headerStyle = assign({}, this.props.headerStyle, {
+    var headerStyle = assign(this.props.headerStyle || {}, {
       display: 'block',
       float: 'none'
     });
@@ -35,8 +35,8 @@ var ExpandableNavHeader = React.createClass({
       fontWeight: 'bold',
       fontSize: 20,
     };
-    var smallStyle = assign({}, this.props.smallStyle, sharedStyle),
-        fullStyle = assign({}, this.props.fullStyle, sharedStyle);
+    var smallStyle = assign(this.props.smallStyle || {}, sharedStyle),
+        fullStyle = assign(this.props.fullStyle || {}, sharedStyle);
 
     var classes = "navbar-header " +
       joinClasses(this.props.className, this.props.expanded ? this.props.fullClass : this.props.smallClass);

--- a/src/components/ExpandableNavHeader.jsx
+++ b/src/components/ExpandableNavHeader.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavItem = require('./ExpandableNavItem');

--- a/src/components/ExpandableNavItem.jsx
+++ b/src/components/ExpandableNavItem.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react/addons');
 
-var assign = require('lodash.assign');
+var assign = require('object-assign');
 
 var ExpandableNavItem = React.createClass({
   propTypes: {

--- a/src/components/ExpandableNavMenu.jsx
+++ b/src/components/ExpandableNavMenu.jsx
@@ -3,7 +3,7 @@
 var React = require('react/addons');
 
 var joinClasses = require('../utils/joinClasses'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavMenu = React.createClass({
   propTypes: {

--- a/src/components/ExpandableNavMenuItem.jsx
+++ b/src/components/ExpandableNavMenuItem.jsx
@@ -58,11 +58,11 @@ var ExpandableNavMenuItem = React.createClass({
     var aStyle = {
       padding: 0
     };
-    var smallStyle = assign({}, this.props.smallStyle, {
+    var smallStyle = assign(this.props.smallStyle || {}, {
       display: 'block',
       fontSize: 20,
     });
-    var fullStyle = assign({}, this.props.fullStyle, {
+    var fullStyle = assign(this.props.fullStyle || {}, {
       display: 'block',
       fontSize: 20,
     });

--- a/src/components/ExpandableNavMenuItem.jsx
+++ b/src/components/ExpandableNavMenuItem.jsx
@@ -58,11 +58,11 @@ var ExpandableNavMenuItem = React.createClass({
     var aStyle = {
       padding: 0
     };
-    var smallStyle = assign(this.props.smallStyle, {
+    var smallStyle = assign({}, this.props.smallStyle, {
       display: 'block',
       fontSize: 20,
     });
-    var fullStyle = assign(this.props.fullStyle, {
+    var fullStyle = assign({}, this.props.fullStyle, {
       display: 'block',
       fontSize: 20,
     });

--- a/src/components/ExpandableNavMenuItem.jsx
+++ b/src/components/ExpandableNavMenuItem.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavItem = require('./ExpandableNavItem');

--- a/src/components/ExpandableNavPage.jsx
+++ b/src/components/ExpandableNavPage.jsx
@@ -1,7 +1,7 @@
 'use strict';
 
 var React = require('react'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavPage = React.createClass({
   propTypes: {

--- a/src/components/ExpandableNavToggleButton.jsx
+++ b/src/components/ExpandableNavToggleButton.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react/addons');
 
-var assign = require('lodash.assign'),
+var assign = require('object-assign'),
     joinClasses = require('../utils/joinClasses');
 
 var ExpandableNavToggleButton = React.createClass({

--- a/src/components/ExpandableNavbar.jsx
+++ b/src/components/ExpandableNavbar.jsx
@@ -3,7 +3,7 @@
 var React = require('react/addons');
 
 var joinClasses = require('../utils/joinClasses'),
-    assign = require('lodash.assign');
+    assign = require('object-assign');
 
 var ExpandableNavbar = React.createClass({
   propTypes: {


### PR DESCRIPTION
`lodash` wants way too many dependencies to polyfill `object.assign`.

this is a `npm list` output:

```
├─┬ react-expandable-nav@0.1.18 
│ ├─┬ lodash.assign@2.4.1 
│ │ ├─┬ lodash._basecreatecallback@2.4.1 
│ │ │ ├─┬ lodash._setbinddata@2.4.1 
│ │ │ │ └── lodash.noop@2.4.1 
│ │ │ ├─┬ lodash.bind@2.4.1 
│ │ │ │ ├─┬ lodash._createwrapper@2.4.1 
│ │ │ │ │ ├─┬ lodash._basebind@2.4.1 
│ │ │ │ │ │ └── lodash._basecreate@2.4.1 
│ │ │ │ │ └── lodash._basecreatewrapper@2.4.1 
│ │ │ │ └── lodash._slice@2.4.1 
│ │ │ ├── lodash.identity@2.4.1 
│ │ │ └── lodash.support@2.4.1 
│ │ ├── lodash._objecttypes@2.4.1 
│ │ └─┬ lodash.keys@2.4.1 
│ │   ├── lodash._isnative@2.4.1 
│ │   ├── lodash._shimkeys@2.4.1 
│ │   └── lodash.isobject@2.4.1 
│ └─┬ lodash.zip@2.4.1 
│   ├─┬ lodash.max@2.4.1 
│   │ ├── lodash._charatcallback@2.4.1 
│   │ ├─┬ lodash.createcallback@2.4.3 
│   │ │ ├─┬ lodash._baseisequal@2.4.1 
│   │ │ │ ├─┬ lodash._getarray@2.4.1 
│   │ │ │ │ └── lodash._arraypool@2.4.1 
│   │ │ │ ├─┬ lodash._releasearray@2.4.1 
│   │ │ │ │ └── lodash._maxpoolsize@2.4.1 
│   │ │ │ └── lodash.forin@2.4.1 
│   │ │ ├── lodash.keys@2.4.1 
│   │ │ └── lodash.property@2.4.1 
│   │ ├── lodash.foreach@2.4.1 
│   │ ├─┬ lodash.forown@2.4.1 
│   │ │ └── lodash.keys@2.4.1 
│   │ ├── lodash.isarray@2.4.1 
│   │ └── lodash.isstring@2.4.1 
│   └─┬ lodash.pluck@2.4.1 
│     └── lodash.map@2.4.1 
```

So, I replaced `lodash.assign` with `object-assign` which is already installed with `babel`. `lodash.zip` is not used at all.

App before replacement:

```
$ webpack
           Asset     Size  Chunks             Chunk Names
    ./www/App.js  1.35 MB       0  [emitted]  App
./www/App.js.map  1.62 MB       0  [emitted]  App
    + 392 hidden modules
```

App after replacement:

```
$ webpack
           Asset     Size  Chunks             Chunk Names
    ./www/App.js  1.32 MB       0  [emitted]  App
./www/App.js.map  1.58 MB       0  [emitted]  App
    + 374 hidden modules
```
